### PR TITLE
fixed issue when searching for attendees check in will not work correctly

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -6,6 +6,10 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
+    "paths": {
+      "$components/*": ["./components/*"]
+    },
+    "baseUrl": "src",
 
     /* Bundler mode */
     "moduleResolution": "bundler",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,10 @@
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
+import tsconfigPath from "vite-tsconfig-paths";
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), tsconfigPath()],
   base: "/project-carnelian/",
 });
 


### PR DESCRIPTION
Fixed issue that when using the search bar to filter for attendee, the check in will not work correct due to the fact that check in is index based and by filtering, an entry will lose its original index. 

The fix is by attaching a hidden id field to the table. For now they will stay in the export file.